### PR TITLE
add a package.json file, publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "timoxley-offset",
+  "description": "Get offset of a dom element.",
+  "version": "0.0.3",
+  "keywords": [],
+  "dependencies": {
+    "dom-support": "*",
+    "within-document": "*"
+  },
+  "component": {
+    "scripts": {
+      "offset/index.js": "index.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/timoxley/offset.git"
+  }
+}


### PR DESCRIPTION
I've [published this component to npm](https://www.npmjs.org/package/timoxley-offset) and added `timoxley` as an owner. This module now works with browserify, however the name on npm is namespaced as `timoxley-offset`, since `offset` was already taken.

If you would merge this `package.json` file then I won't need to maintain my fork.

Cheers!
