### PR TITLE
Use "within-element" and "get-document" for Range support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # offset
 
-  Get offset of a dom element within the viewport.
+  Get offset of a DOM Element or Range within the viewport.
 
 ## Installation
 

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "offset",
   "repo": "timoxley/offset",
-  "description": "Get offset of a dom element.",
+  "description": "Get offset of a DOM Element or Range within the viewport",
   "version": "0.0.3",
   "keywords": [],
   "dependencies": {

--- a/index.js
+++ b/index.js
@@ -3,9 +3,11 @@ var getDocument = require('get-document')
 var withinElement = require('within-element')
 
 /**
- * Get offset of an element within the viewport.
+ * Get offset of a DOM Element or Range within the viewport.
  *
- * @api public
+ * @param {DOMElement|Range} el - the DOM element or Range instance to measure
+ * @return {Object} An object with `top` and `left` Number values
+ * @public
  */
 
 module.exports = function offset(el) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timoxley-offset",
-  "description": "Get offset of a dom element.",
+  "description": "Get offset of a DOM Element or Range within the viewport",
   "version": "0.0.3",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
Hey @timoxley! So we've been using this module to do measurements on Range objects (text selections) within the web page. So far we've had to hack it by setting `range.ownerDocument = document` and `range.parentNode = document`. But these new dependencies have Range support built-in, so these hacks are no longer necessary on our end.

Hoping we can merge this and publish a new npm version. Cheers!
