### PR TITLE
Describe as "offset in document" instead of "viewport"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # offset
 
-  Get offset of a DOM Element or Range within the viewport.
+  Get offset of a DOM Element or Range within the document.
 
 ## Installation
 
@@ -10,7 +10,8 @@
 
 ### offset(el)
 
-Get offset of an element within the viewport.
+Get offset of an element within the document (relative to the top left
+of the document).
 
 Example:
 

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "offset",
   "repo": "timoxley/offset",
-  "description": "Get offset of a DOM Element or Range within the viewport",
+  "description": "Get offset of a DOM Element or Range within the document",
   "version": "1.0.1",
   "keywords": ["coordinates"],
   "dependencies": {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var getDocument = require('get-document')
 var withinElement = require('within-element')
 
 /**
- * Get offset of a DOM Element or Range within the viewport.
+ * Get offset of a DOM Element or Range within the document.
  *
  * @param {DOMElement|Range} el - the DOM element or Range instance to measure
  * @return {Object} An object with `top` and `left` Number values

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timoxley-offset",
-  "description": "Get offset of a DOM Element or Range within the viewport",
+  "description": "Get offset of a DOM Element or Range within the document",
   "version": "1.0.1",
   "keywords": [
     "browser",


### PR DESCRIPTION
The current description of "offset in viewport" is not intuitive to me.

The position returned is relative to the document, not the viewport. The viewport is the area visible to the user (i.e., the browser window, see [1]), so it would be expected that the return value changes as the user scrolls the document. This is _not_ the case for the value returned by this module. I think "offset in _document_" is a more accurate description.

If you agree, I'd also consider changing the GitHub repository description and publishing to npm as something like _offset-in-document_.

[1] http://www.quirksmode.org/mobile/viewports.html#link9
